### PR TITLE
general: Keyword-only bool arguments

### DIFF
--- a/openemail/core/client.py
+++ b/openemail/core/client.py
@@ -837,7 +837,11 @@ async def _fetch_envelope(
 
 
 async def _fetch_message_from_agent(
-    url: str, author: Address, ident: str, broadcast: bool = False
+    url: str,
+    author: Address,
+    ident: str,
+    *,
+    broadcast: bool = False,
 ) -> Message | None:
     logger.debug("Fetching message %s…", ident[:_SHORT])
 
@@ -902,7 +906,7 @@ async def _fetch_message_from_agent(
     return message
 
 
-async def _fetch_message_ids(author: Address, broadcasts: bool = False) -> set[str]:
+async def _fetch_message_ids(author: Address, *, broadcasts: bool = False) -> set[str]:
     """Fetch link or broadcast message IDs by `author`, addressed to `client.user`."""
     logger.debug("Fetching message IDs from %s…", author)
 

--- a/openemail/mail.py
+++ b/openemail/mail.py
@@ -201,7 +201,7 @@ class ProfileStore(DictStore[Address, Profile]):
         self._items[contact] = Profile.of(contact)
         self.items_changed(len(self._items) - 1, 0, 1)
 
-    async def update_profiles(self, trust_images: bool = True) -> None:
+    async def update_profiles(self, *, trust_images: bool = True) -> None:
         """Update the profiles of contacts in the user's address book.
 
         If `trust_images` is set to `False`, profile images will not be loaded.
@@ -442,7 +442,11 @@ class IncomingAttachment(Attachment):
             return
 
         try:
-            stream = gfile.replace(None, True, Gio.FileCreateFlags.REPLACE_DESTINATION)
+            stream = gfile.replace(
+                etag=None,
+                make_backup=False,
+                flags=Gio.FileCreateFlags.REPLACE_DESTINATION,
+            )
             await cast(
                 "Awaitable",
                 stream.write_bytes_async(GLib.Bytes.new(data), GLib.PRIORITY_DEFAULT),
@@ -947,7 +951,7 @@ def register(
     run_task(auth(), done)
 
 
-async def sync(periodic: bool = False) -> None:
+async def sync(*, periodic: bool = False) -> None:
     """Populate the app's content by fetching the user's data."""
     Notifier().syncing = True
 

--- a/openemail/widgets/compose_dialog.py
+++ b/openemail/widgets/compose_dialog.py
@@ -201,7 +201,7 @@ class ComposeDialog(Adw.Dialog):
         async for attachment in OutgoingAttachment.choose(self):
             self.attachments.model.append(attachment)
 
-    def _format_line(self, syntax: str, toggle: bool = False) -> None:
+    def _format_line(self, syntax: str, *, toggle: bool = False) -> None:
         start = self.body.get_iter_at_offset(self.body.props.cursor_position)
         start.set_line_offset(0)
 


### PR DESCRIPTION
Tbh some of these are dubious, but I agree in principle. Would be good to do another round around all the cases, and seeing whether they really should be bools in the first place:

> ...consider refactoring into separate implementations for the True and False cases, using an Enum, or making the argument a keyword-only argument...