### PR TITLE
ui: Set proper size requests

### DIFF
--- a/openemail/gtk/ui/compose-sheet.blp
+++ b/openemail/gtk/ui/compose-sheet.blp
@@ -3,8 +3,8 @@ using Adw 1;
 using Gio 2.0;
 
 template $ComposeSheet: Adw.BreakpointBin {
-  width-request: 360;
-  height-request: 294;
+  width-request: bind template.root as <Adw.ApplicationWindow>.width-request;
+  height-request: bind template.root as <Adw.ApplicationWindow>.height-request;
   body: bind body_view.buffer;
 
   Adw.Breakpoint {
@@ -23,8 +23,8 @@ template $ComposeSheet: Adw.BreakpointBin {
     align: 0.02;
 
     sheet: Adw.BreakpointBin {
-      width-request: 360;
-      height-request: 294;
+      width-request: bind template.width-request;
+      height-request: bind template.height-request;
 
       Adw.Breakpoint {
         condition ("max-width: 450")

--- a/openemail/gtk/ui/page.blp
+++ b/openemail/gtk/ui/page.blp
@@ -2,8 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template $Page: Adw.BreakpointBin {
-  width-request: 360;
-  height-request: 294;
+  width-request: bind template.root as <Adw.ApplicationWindow>.width-request;
+  height-request: bind template.root as <Adw.ApplicationWindow>.height-request;
 
   Adw.Breakpoint {
     condition ("max-width: 600")


### PR DESCRIPTION
Libadwaita changed the default Adw.ApplicationWindow height from 294 to 200, so these widgets were raising warnings.

https://gitlab.gnome.org/GNOME/libadwaita/-/commit/7a705c7959d784fa6d40af202d5d06d06f1e2fa6